### PR TITLE
Accomodate multiple versions of a log processor

### DIFF
--- a/log-processors.yaml
+++ b/log-processors.yaml
@@ -1,0 +1,10 @@
+agents:
+  - fluent-bit:
+      version: 1.8
+      location: /opt/fluent-bit/bin/fluent-bit
+  - fluent-bit:
+      version: 1.9
+      location: /opt/fluent-bit/bin/fluent-bit
+  - vector:
+      version: 0.21.0
+      location: /home/aditya/.vector/bin/vector


### PR DESCRIPTION
- add a new flag --config that lets users provide a yaml file containing
the log processors, optionally with their versions and path to binary
- report per agent execution times

fixes #5 and #7

Signed-off-by: Syn3rman <aditya@calyptia.com>